### PR TITLE
feat: add /backvtex path prefix support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 PORT=5420
 NODE_ENV=development
 
-API_URL="https://localhost:$PORT"
+API_URL="https://localhost:$PORT/backvtex"
 FRONTEND_URL="https://localhost:3000"
 
 CRYPTOJS_SECRET_KEY=123456

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ OCA_FORCE_PROD=
 | `PORT` | The port number of the server | `5420` |
 | `NODE_ENV` | Node environment | `development` |
 | `DEBUG` | Whether to enable debug mode | `true` |
-| `API_URL` | The URL of the API | `http://localhost:$PORT` |
+| `API_URL` | The URL of the API | `http://localhost:$PORT/backvtex` |
 | `FRONTEND_URL` | The URL of the frontend | `http://localhost:3000` |
 | `MONGODB_URL` | The URL of the Mongo DB | `mongodb://127.0.0.1:27017/carrier-vtex`|
 | `CRYPTOJS_SECRET_KEY` | The secret key for Crypto JS | `123456` |
@@ -208,7 +208,7 @@ OCA_FORCE_PROD=
 
 ### API Endpoints
 
-List of available routes (base path: `/api/v1`):
+List of available routes (base path: `/backvtex/api/v1`):
 
 **Auth routes**:\
 `GET /login` - App login\


### PR DESCRIPTION
## Summary
- derive backend base path from API_URL
- document /backvtex prefix in env example and README

## Testing
- `npm test`
- `npm run lint` *(fails: Unable to resolve path to module 'postman-to-openapi')*
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68964b7782f0832f8e46c820aa92475a